### PR TITLE
Update variant.h

### DIFF
--- a/buildroot/share/PlatformIO/variants/BIGTREE_SKR_PRO_1v1/variant.h
+++ b/buildroot/share/PlatformIO/variants/BIGTREE_SKR_PRO_1v1/variant.h
@@ -245,10 +245,13 @@ extern "C" {
 #define PIN_SPI_SS              PB12
 
 // I2C Definitions
-#define PIN_WIRE_SDA            PB7
-#define PIN_WIRE_SCL            PB6	
-
-
+#if STM32F4X_PIN_NUM >= 176
+	#define PIN_WIRE_SDA            PH5
+	#define PIN_WIRE_SCL            PH4	
+#else 
+	#define PIN_WIRE_SDA            PB7
+	#define PIN_WIRE_SCL            PB6	
+#endif
 // Timer Definitions
 //Do not use timer used by PWM pins when possible. See PinMap_PWM in PeripheralPins.c
 #define TIMER_TONE              TIM2


### PR DESCRIPTION
Added eeprom pin definitions for different f407xx chips

### Requirements
Fix for failed eeprom initialization on GTR motherboard in latest firmware

### Description

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits
GTR motherboard external eeprom initialization through 
<!-- What does this fix or improve? -->

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
